### PR TITLE
Add support for customising the rule name for use with Laravel 6/7

### DIFF
--- a/config/password-policy.php
+++ b/config/password-policy.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+
+    /*
+     |--------------------------------------------------------------------------
+     | Password Policy Settings
+     |--------------------------------------------------------------------------
+     |
+     | Configure the rule name used when validating a password.
+     |
+     */
+
+    'rule' => 'password',
+
+];

--- a/src/PasswordPolicy/Providers/Laravel/PasswordPolicyServiceProvider.php
+++ b/src/PasswordPolicy/Providers/Laravel/PasswordPolicyServiceProvider.php
@@ -20,6 +20,9 @@ class PasswordPolicyServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        $configPath = __DIR__ . '/../../../../config/password-policy.php';
+        $this->mergeConfigFrom($configPath, 'password-policy');
+
         $this->registerManager();
         $this->registerBuilder();
         $this->registerFacade();
@@ -33,6 +36,9 @@ class PasswordPolicyServiceProvider extends ServiceProvider
      */
     public function boot()
     {
+        $configPath = __DIR__ . '/../../../../config/password-policy.php';
+        $this->publishes([$configPath => $this->getConfigPath()], 'config');
+
         $this->configureValidationRule();
     }
 
@@ -63,7 +69,7 @@ class PasswordPolicyServiceProvider extends ServiceProvider
      */
     protected function configureValidationRule()
     {
-        $this->app['validator']->extend('password', PasswordValidator::class . '@validate');
+        $this->app['validator']->extend($this->app['config']->get('password-policy.rule'), PasswordValidator::class . '@validate');
     }
 
     /**
@@ -103,5 +109,15 @@ class PasswordPolicyServiceProvider extends ServiceProvider
     protected function defaultPolicy(PolicyBuilder $builder)
     {
         return $builder->getPolicy();
+    }
+
+    /**
+     * Get the config path
+     *
+     * @return string
+     */
+    protected function getConfigPath()
+    {
+        return config_path('password-policy.php');
     }
 }


### PR DESCRIPTION
This allows the package to be used in Laravel 6/7 by allowing customisation of the rule name.
In Laravel 6 a `password` validation rule was added with different functionality: https://laravel.com/docs/6.x/validation#rule-password

To use the package with Laravel 6/7 publish the config file:
```
php artisan vendor:publish --provider="PasswordPolicy\Providers\Laravel\PasswordPolicyServiceProvider"
```

Then specify a different name for the rule in the config e.g. `password_policy` and it will fix #7.
